### PR TITLE
ci: use reusable Doxygen GH Pages workflow from makers-devops

### DIFF
--- a/.github/workflows/doxygen_gh.yml
+++ b/.github/workflows/doxygen_gh.yml
@@ -2,50 +2,15 @@ name: Doxygen GH
 
 on:
   push:
-    branches: [ master, develop ]
+    branches: [ master ]
   pull_request:
-    branches: [ master, develop ]
+    branches: [ master ]
+
+permissions:
+  contents: write
 
 jobs:
-  build-documentation:
-
-    runs-on: ubuntu-latest
-
-    steps:
-
-    - uses: actions/checkout@v2
-    - name: Cache pip
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-        restore-keys: ${{ runner.os }}-pip-
-
-    - name: Set up Python
-      uses: actions/setup-python@v2
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Install doxygen
-      run: |
-        sudo apt-get install -y doxygen
-        sudo apt-get install -y graphviz
-    - name: Run doxygen
-      run: |
-        git clone https://github.com/Infineon/InfineonDoxyGenerator.git
-        cd InfineonDoxyGenerator
-        python doxyifx.py html
-        #python doxyifx.py release ${{ secrets.GH_USER }} ${{ secrets.GITHUB_TOKEN }}
-    
-    - name: GH Pages Deployment
-      uses: peaceiris/actions-gh-pages@v3
-      if: success()
-      with:
-        publish_dir: ./docs/doxygen/build/html/
-        enable_jekyll: false
-        allow_empty_commit: false
-        force_orphan: true
-        publish_branch: gh-pages
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+  call-doxygen-gh-pages:
+    uses: Infineon/makers-devops/.github/workflows/doxygen_gh_pages.yml@main
+    permissions:
+      contents: write


### PR DESCRIPTION
## Summary

Replaces the inline Doxygen build and GitHub Pages deployment steps with a call to the centralized reusable workflow maintained in [Infineon/makers-devops](https://github.com/Infineon/makers-devops).

## Changes

- `.github/workflows/doxygen_gh.yml`: Replace ~50 lines of inline steps (checkout, pip cache, Python setup, doxygen install, build, deploy) with a single `uses:` call to `Infineon/makers-devops/.github/workflows/doxygen_gh_pages.yml@main`

## Motivation

- **Consistency**: All repos use the same workflow logic from a single source of truth
- **Maintainability**: Future improvements to the Doxygen build or deployment only need to be made in one place
- **Reduced duplication**: Eliminates repeated boilerplate across multiple repositories